### PR TITLE
T005 Add domain errors and types

### DIFF
--- a/feature/media/media_domain/src/main/kotlin/com/davidluna/tmdb/media_domain/favorites/errors/FavoriteError.kt
+++ b/feature/media/media_domain/src/main/kotlin/com/davidluna/tmdb/media_domain/favorites/errors/FavoriteError.kt
@@ -1,0 +1,8 @@
+package com.davidluna.tmdb.media_domain.favorites.errors
+
+sealed class FavoriteError(val message: String, val cause: Throwable? = null) {
+    data object NotFound : FavoriteError("Favorite not found")
+
+    data class Local(val throwable: Throwable?) :
+        FavoriteError(throwable?.message ?: "Local error", throwable)
+}

--- a/feature/media/media_domain/src/main/kotlin/com/davidluna/tmdb/media_domain/favorites/types/MediaType.kt
+++ b/feature/media/media_domain/src/main/kotlin/com/davidluna/tmdb/media_domain/favorites/types/MediaType.kt
@@ -1,0 +1,5 @@
+package com.davidluna.tmdb.media_domain.favorites.types
+
+enum class MediaType {
+    MOVIE, TV_SHOW
+}


### PR DESCRIPTION
Adds favorites domain error type and media type enum.

Closes #12

Note: Repository/use cases will consume these types in follow-up tasks.