### PR TITLE
T015 Wire list toggle through FavoritesViewModel

### DIFF
--- a/feature/media/media_ui/src/main/kotlin/com/davidluna/tmdb/media_ui/favorites/viewmodel/FavoritesViewModel.kt
+++ b/feature/media/media_ui/src/main/kotlin/com/davidluna/tmdb/media_ui/favorites/viewmodel/FavoritesViewModel.kt
@@ -1,0 +1,34 @@
+package com.davidluna.tmdb.media_ui.favorites.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.davidluna.tmdb.media_domain.favorites.entities.FavoriteItem
+import com.davidluna.tmdb.media_domain.favorites.usecase.ToggleFavoriteUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class FavoritesViewModel @Inject constructor(
+    private val toggleFavoriteUseCase: ToggleFavoriteUseCase,
+) : ViewModel() {
+
+    private val _favoriteIds = MutableStateFlow<Set<Int>>(emptySet())
+    val favoriteIds: StateFlow<Set<Int>> = _favoriteIds.asStateFlow()
+
+    fun onToggleFavorite(item: FavoriteItem) {
+        val previous = _favoriteIds.value
+        val updated = if (previous.contains(item.id)) previous - item.id else previous + item.id
+        _favoriteIds.value = updated
+
+        viewModelScope.launch {
+            val result = toggleFavoriteUseCase(item)
+            if (result.isLeft()) {
+                _favoriteIds.value = previous
+            }
+        }
+    }
+}

--- a/feature/media/media_ui/src/main/kotlin/com/davidluna/tmdb/media_ui/presenter/media/MediaCatalogViewModel.kt
+++ b/feature/media/media_ui/src/main/kotlin/com/davidluna/tmdb/media_ui/presenter/media/MediaCatalogViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import com.davidluna.tmdb.core_domain.entities.AppError
 import com.davidluna.tmdb.core_domain.entities.toAppError
+import com.davidluna.tmdb.media_domain.entities.Catalog
 import com.davidluna.tmdb.media_domain.entities.Catalog.MOVIE_UPCOMING
 import com.davidluna.tmdb.media_domain.entities.Catalog.TV_AIRING_TODAY
 import com.davidluna.tmdb.media_domain.entities.Media
@@ -61,6 +62,7 @@ class MediaCatalogViewModel @Inject constructor(
         val gridCatalogTitle: Int? = null,
         val pagerCatalogTitle: Int? = null,
         val lastKnownPosition: Pair<MediaIndex, MediaOffset> = 0 to 0,
+        val selectedCatalog: Catalog? = null,
     )
 
     fun updateLastKnownPosition(index: MediaIndex, offset: MediaOffset) {
@@ -72,7 +74,7 @@ class MediaCatalogViewModel @Inject constructor(
         .distinctUntilChanged()
         .catch { e -> _state.update { it.copy(appError = e.toAppError()) } }
         .flatMapLatest { mediaCatalog ->
-            _state.update { it.copy(gridCatalogTitle = mediaCatalog.title) }
+            _state.update { it.copy(gridCatalogTitle = mediaCatalog.title, selectedCatalog = mediaCatalog) }
             observeMediaCatalogUseCase(mediaCatalog, viewModelScope)
         }
 

--- a/feature/media/media_ui/src/main/kotlin/com/davidluna/tmdb/media_ui/view/media/MediaCatalogScreen.kt
+++ b/feature/media/media_ui/src/main/kotlin/com/davidluna/tmdb/media_ui/view/media/MediaCatalogScreen.kt
@@ -1,6 +1,7 @@
 package com.davidluna.tmdb.media_ui.view.media
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
@@ -11,6 +12,7 @@ import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -19,11 +21,21 @@ import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import com.davidluna.tmdb.core_domain.entities.AppError
 import com.davidluna.tmdb.core_ui.composables.ErrorDialogView
 import com.davidluna.tmdb.core_ui.navigation.Destination
 import com.davidluna.tmdb.core_ui.theme.dimens.Dimens
+import com.davidluna.tmdb.media_domain.entities.Catalog
 import com.davidluna.tmdb.media_domain.entities.Media
+import com.davidluna.tmdb.media_domain.entities.MediaType as CatalogMediaType
+import com.davidluna.tmdb.media_domain.favorites.entities.FavoriteItem
+import com.davidluna.tmdb.media_domain.favorites.types.MediaType as FavoriteMediaType
+import com.davidluna.tmdb.media_ui.favorites.viewmodel.FavoritesViewModel
 import com.davidluna.tmdb.media_ui.navigation.MediaNavigation.Detail
 import com.davidluna.tmdb.media_ui.presenter.media.MediaCatalogViewModel
 import com.davidluna.tmdb.media_ui.view.media.composables.CarouselImageView
@@ -35,11 +47,13 @@ import com.davidluna.tmdb.media_ui.view.media.composables.ReelTitleView
 @Composable
 fun MediaCatalogScreen(
     viewModel: MediaCatalogViewModel = hiltViewModel(),
+    favoritesViewModel: FavoritesViewModel = hiltViewModel(),
     navigateTo: (Destination) -> Unit,
 ) {
     val pagerLazyPagingItems = viewModel.pagerPagingDataFlow.collectAsLazyPagingItems()
     val gridLazyPagingItems = viewModel.gridPagingDataFlow.collectAsLazyPagingItems()
     val state by viewModel.state.collectAsStateWithLifecycle()
+    val favoriteIds by favoritesViewModel.favoriteIds.collectAsStateWithLifecycle()
 
     MediaCatalogScreen(
         appError = state.appError,
@@ -48,7 +62,20 @@ fun MediaCatalogScreen(
         lastKnownPosition = state.lastKnownPosition,
         pagerCatalogTitle = state.pagerCatalogTitle?.let { stringResource(it) },
         pagerLazyPagingItems = pagerLazyPagingItems,
+        selectedCatalog = state.selectedCatalog,
+        favoriteIds = favoriteIds,
         navigateTo = { navigateTo(it) },
+        onToggleFavorite = { media, mediaType ->
+            favoritesViewModel.onToggleFavorite(
+                FavoriteItem(
+                    id = media.id,
+                    mediaType = mediaType,
+                    title = media.title,
+                    posterPath = media.posterPath,
+                    timestamp = System.currentTimeMillis()
+                )
+            )
+        },
         onPositionChanged = { index, offset -> viewModel.updateLastKnownPosition(index, offset) }
     )
 }
@@ -61,10 +88,14 @@ fun MediaCatalogScreen(
     lastKnownPosition: Pair<Int, Int>,
     pagerCatalogTitle: String?,
     pagerLazyPagingItems: LazyPagingItems<Media>,
+    selectedCatalog: Catalog?,
+    favoriteIds: Set<Int>,
     navigateTo: (Destination) -> Unit,
+    onToggleFavorite: (Media, FavoriteMediaType) -> Unit,
     onPositionChanged: (Int, Int) -> Unit,
 ) {
     val lazyGridState = rememberLazyGridState()
+    val favoriteMediaType = selectedCatalog?.toFavoriteMediaType()
 
     LaunchedEffect(gridCatalogTitle) {
         if (lazyGridState.firstVisibleItemIndex > 0) {
@@ -128,6 +159,7 @@ fun MediaCatalogScreen(
             key = gridLazyPagingItems.getOrNull { mediaItems -> mediaItems.itemKey { it.id } }
         ) { index ->
             val media: Media? = gridLazyPagingItems.getOrNull { it[index] }
+            val isFavorite = media?.id?.let { favoriteIds.contains(it) } == true
             Column(
                 modifier = Modifier
                     .clickable {
@@ -140,7 +172,24 @@ fun MediaCatalogScreen(
                         }
                     }
             ) {
-                FilmMaskImageView(model = media?.posterPath)
+                Box {
+                    FilmMaskImageView(model = media?.posterPath)
+                    IconButton(
+                        modifier = Modifier.align(Alignment.TopEnd),
+                        enabled = media != null && favoriteMediaType != null,
+                        onClick = {
+                            if (media != null && favoriteMediaType != null) {
+                                onToggleFavorite(media, favoriteMediaType)
+                            }
+                        }
+                    ) {
+                        val icon = if (isFavorite) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder
+                        Icon(
+                            imageVector = icon,
+                            contentDescription = if (isFavorite) "Remove favorite" else "Add favorite"
+                        )
+                    }
+                }
                 MediaTitleView(media?.title)
                 Spacer(modifier = Modifier.padding(top = Dimens.margins.xLarge))
             }
@@ -154,3 +203,6 @@ private fun <T : Any, R : Any> LazyPagingItems<T>.getOrNull(take: (LazyPagingIte
     } catch (_: IndexOutOfBoundsException) {
         null
     }
+
+private fun Catalog.toFavoriteMediaType(): FavoriteMediaType =
+    if (mediaType == CatalogMediaType.MOVIE) FavoriteMediaType.MOVIE else FavoriteMediaType.TV_SHOW


### PR DESCRIPTION
Wires list item favorite toggle through a new FavoritesViewModel and updates MediaCatalogScreen to reflect immediate UI changes.

Closes #20

Depends on #40 (ToggleFavoriteUseCase), #32 (FavoriteItem/MediaType), and #33 (FavoritesRepository contract).