### PR TITLE
T020 Favorites navigation test

### DIFF
--- a/app/src/androidTest/kotlin/com/davidluna/tmdb/app/main_ui/view/favorites/FavoritesScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/davidluna/tmdb/app/main_ui/view/favorites/FavoritesScreenTest.kt
@@ -1,0 +1,21 @@
+package com.davidluna.tmdb.app.main_ui.view.favorites
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.davidluna.tmdb.app.main_ui.view.composables.NavDrawerViewPreview
+import org.junit.Rule
+import org.junit.Test
+
+class FavoritesScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun drawerContainsFavoritesOption(): Unit = composeTestRule.run {
+        setContent { NavDrawerViewPreview() }
+
+        onNodeWithText("Favorites").assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
Adds a failing drawer test expecting a Favorites option.

Closes #21

Note: Drawer lives in app module, so the test is placed under app androidTest.